### PR TITLE
Filter pulls from issues list

### DIFF
--- a/internal/api/issues.go
+++ b/internal/api/issues.go
@@ -7,6 +7,18 @@ import (
 	"github.com/hirakiuc/alfred-github-workflow/internal/model"
 )
 
+func filterIssues(issues []*github.Issue) []*github.Issue {
+	results := []*github.Issue{}
+
+	for _, issue := range issues {
+		if issue.GetPullRequestLinks() == nil {
+			results = append(results, issue)
+		}
+	}
+
+	return results
+}
+
 // FetchIssues fetch the issues in the repository.
 func (client *Client) FetchIssues(ctx context.Context, owner string, repo string) ([]model.Issue, error) {
 	opt := github.IssueListByRepoOptions{
@@ -22,6 +34,9 @@ func (client *Client) FetchIssues(ctx context.Context, owner string, repo string
 		if err != nil {
 			return items, err
 		}
+
+		// Remove PullRequests
+		issues = filterIssues(issues)
 
 		items = append(items, model.ConvertIssues(issues)...)
 


### PR DESCRIPTION
https://developer.github.com/v3/issues/#list-issues-for-a-repository

> Note: GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response. You can identify pull requests by the pull_request key.
> 
> Be aware that the id of a pull request returned from "Issues" endpoints will be an issue id. To find out the pull request id, use the "List pull requests" endpoint.

This PR remove PRs from issues list.