### PR TITLE
Migrate coverate service from codecov to coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
+
 executors:
   go-executor:
     docker:
@@ -57,7 +60,8 @@ jobs:
       - run:
           command: |
             go test -race -coverprofile=cover.out -covermode=atomic ./...
-            bash <(curl -s https://codecov.io/bash)
+      - coveralls/upload:
+          path_to_lcov: "./cover.out"
 
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/hirakiuc/alfred-github-workflow/tree/master.svg?style=svg&circle-token=fa58af4989cde7043d7b8ea72e53359355d7da9c)](https://circleci.com/gh/hirakiuc/alfred-github-workflow/tree/master)
-[![codecov](https://codecov.io/gh/hirakiuc/alfred-github-workflow/branch/master/graph/badge.svg)](https://codecov.io/gh/hirakiuc/alfred-github-workflow)
+[![Coverage Status](https://coveralls.io/repos/github/hirakiuc/alfred-github-workflow/badge.svg?branch=master)](https://coveralls.io/github/hirakiuc/alfred-github-workflow?branch=master)
 
 # alfred-github-workflow
 


### PR DESCRIPTION
# WHAT

- migrate coverage service from codecov to coveralls

# WHY

- not to use codecov
